### PR TITLE
add an option to configure service worker setup messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ pwa:
         strategy: cacheFirst
       - pattern: !!js/regexp /\//
         strategy: networkFirst
+    # set console to `none` to hide all the setup messages or `error` to hide normal logs. (default: show all logs)
+    console: error
   priority: 5
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ pwa:
         strategy: cacheFirst
       - pattern: !!js/regexp /\//
         strategy: networkFirst
-    # set console to `none` to hide all the setup messages or `error` to hide normal logs. (default: show all logs)
     console: error
   priority: 5
 ```
@@ -70,6 +69,7 @@ pwa:
 	- routes - request routes and strategies, based on [sw-toolbox](https://googlechromelabs.github.io/sw-toolbox/#main). **The routes order does matter**.
 		- pattern: url pattern, this config can be express-style or RegExp
 		- strategy: the strategy you want to choose. [All strategies](https://googlechromelabs.github.io/sw-toolbox/api.html#options): `cacheFirst`, `networkFirst`, `cacheOnly`, `networkOnly`, `fastest`. Caution: Log requests should use `networkOnly` strategy.
+	- console: console log level, set to `none` to hide all the setup messages or `error` to hide normal logs. The default option is `all`(show all logs)
 - priority - [plugin priority](https://hexo.io/api/filter.html) (default value is 10)
 
 ## License

--- a/index.js
+++ b/index.js
@@ -25,7 +25,10 @@ if (hexo.config.pwa.manifest) {
 if (hexo.config.pwa.serviceWorker) {
   // get sw register code and compile
   let swTpl = fs.readFileSync(path.resolve(__dirname, './templates/swRegister.tpl.js'));
-  compiledSWRegTpl = tpl(swTpl)({path: hexo.config.pwa.serviceWorker.path + '?t=' + Date.now()});
+  compiledSWRegTpl = tpl(swTpl)({
+    path: hexo.config.pwa.serviceWorker.path + '?t=' + Date.now(),
+    console: hexo.config.pwa.serviceWorker.console,
+  });
   // generate service worker file
   hexo.extend.generator.register('serviceWorker', serviceWorkerGenerator);
 }

--- a/templates/swRegister.tpl.js
+++ b/templates/swRegister.tpl.js
@@ -1,5 +1,13 @@
 if ('serviceWorker' in navigator) {
   navigator.serviceWorker.register('<%=path %>')
-    .then(function () {console.log('ServiceWorker Register Successfully.')})
-    .catch(function (e) {console.error(e)});
+    .then(function() {
+      if ('<%=console %>' !== 'none') {
+        console.log('ServiceWorker Register Successfully.');
+      }
+    })
+    .catch(function(e) {
+      if (['error', 'none'].indexOf('<%=console %>') === -1) {
+        console.error(e);
+      }
+    });
 }


### PR DESCRIPTION
Hi, @PengXing 
I think it will be great to add an option for developers to decide whether or not to show the service worker setup messages in the console.
I will be appreciated if you can accept this pull request.