### PR TITLE
Fix bug

### DIFF
--- a/lib/serviceWorker.js
+++ b/lib/serviceWorker.js
@@ -21,7 +21,7 @@ module.exports = function(locals) {
   let precacheUrls = (config.preload && config.preload.urls) || [];
 
   let postsCount = config.preload.posts;
-  let posts = this.locals.cache.posts.data;
+  let posts = this.locals.cache.get('posts').data;
 
   // sort posts by publishing date
   posts.sort((a, b) => b.date - a.date);


### PR DESCRIPTION
Fix error when generate
```
FATAL {
  err: TypeError: Cannot read property 'data' of undefined
      at Hexo.module.exports (/home/simba/blog/node_modules/hexo-pwa/lib/serviceWorker.js:23:39)
      at Hexo.tryCatcher (/home/simba/blog/node_modules/bluebird/js/release/util.js:16:23)
      at Hexo.<anonymous> (/home/simba/blog/node_modules/bluebird/js/release/method.js:15:34)
      at /home/simba/blog/node_modules/hexo/lib/hexo/index.js:405:22
      at tryCatcher (/home/simba/blog/node_modules/bluebird/js/release/util.js:16:23)
      at MappingPromiseArray._promiseFulfilled (/home/simba/blog/node_modules/bluebird/js/release/map.js:68:38)
      at MappingPromiseArray.PromiseArray._iterate (/home/simba/blog/node_modules/bluebird/js/release/promise_array.js:115:31)
      at MappingPromiseArray.init (/home/simba/blog/node_modules/bluebird/js/release/promise_array.js:79:10)
      at MappingPromiseArray._asyncInit (/home/simba/blog/node_modules/bluebird/js/release/map.js:37:10)
      at _drainQueueStep (/home/simba/blog/node_modules/bluebird/js/release/async.js:97:12)
      at _drainQueue (/home/simba/blog/node_modules/bluebird/js/release/async.js:86:9)
      at Async._drainQueues (/home/simba/blog/node_modules/bluebird/js/release/async.js:102:5)
      at Immediate.Async.drainQueues [as _onImmediate] (/home/simba/blog/node_modules/bluebird/js/release/async.js:15:14)
      at processImmediate (internal/timers.js:461:21)
} Something's wrong. Maybe you can find the solution here: %s https://hexo.io/docs/troubleshooting.html

```